### PR TITLE
Feature/22 One Call API 3.0 를 사용하는 WebClient 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/team04/back/config/WebClientConfig.java
+++ b/src/main/java/com/team04/back/config/WebClientConfig.java
@@ -1,0 +1,15 @@
+package com.team04.back.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient weatherApiWebClient(WebClient.Builder builder) {
+        WebClient build = builder.baseUrl("https://api.openweathermap.org/data/2.5/weather")
+                .build();
+        return build;
+    }
+}

--- a/src/main/java/com/team04/back/config/WebClientConfig.java
+++ b/src/main/java/com/team04/back/config/WebClientConfig.java
@@ -8,7 +8,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class WebClientConfig {
     @Bean
     public WebClient weatherApiWebClient(WebClient.Builder builder) {
-        WebClient build = builder.baseUrl("https://api.openweathermap.org/data/2.5/weather")
+        WebClient build = builder.baseUrl("https://api.openweathermap.org")
                 .build();
         return build;
     }

--- a/src/main/java/com/team04/back/domain/cloth/clothinfo/controller/ClothInfoController.java
+++ b/src/main/java/com/team04/back/domain/cloth/clothinfo/controller/ClothInfoController.java
@@ -1,12 +1,45 @@
 package com.team04.back.domain.cloth.clothinfo.controller;
 
+import com.team04.back.domain.cloth.clothinfo.dto.OutfitResponse;
 import com.team04.back.domain.cloth.clothinfo.service.ClothInfoService;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PastOrPresent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
+
 @RestController
+@RequestMapping("/api/v1/cloth")
 @RequiredArgsConstructor
 public class ClothInfoController {
     private final ClothInfoService clothInfoService;
+
+
+    record TripSchedule(
+            @NotBlank
+            String place,
+            @NotBlank
+            @PastOrPresent
+            LocalDate start,
+            @NotBlank
+            @Future
+            LocalDate end
+    ) {
+    }
+
+//    @GetMapping
+//    public OutfitResponse getOutfitWithPeriod(@ResponseBody TripSchedule tripSchedule) {
+//        clothInfoService.getOutfitWithPeriod(
+//                tripSchedule.place(),
+//                tripSchedule.start(),
+//                tripSchedule.end()
+//        );
+//        return null;
+//    }
 
 }

--- a/src/main/java/com/team04/back/domain/cloth/clothinfo/controller/ClothInfoController.java
+++ b/src/main/java/com/team04/back/domain/cloth/clothinfo/controller/ClothInfoController.java
@@ -1,0 +1,12 @@
+package com.team04.back.domain.cloth.clothinfo.controller;
+
+import com.team04.back.domain.cloth.clothinfo.service.ClothInfoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ClothInfoController {
+    private final ClothInfoService clothInfoService;
+
+}

--- a/src/main/java/com/team04/back/domain/cloth/clothinfo/dto/OutfitResponse.java
+++ b/src/main/java/com/team04/back/domain/cloth/clothinfo/dto/OutfitResponse.java
@@ -1,0 +1,9 @@
+package com.team04.back.domain.cloth.clothinfo.dto;
+
+import java.util.List;
+
+public record OutfitResponse(
+        List<String> minRequiredItems,
+        List<String> additionalConsiderItems
+) {
+}

--- a/src/main/java/com/team04/back/domain/cloth/clothinfo/entity/ClothInfo.java
+++ b/src/main/java/com/team04/back/domain/cloth/clothinfo/entity/ClothInfo.java
@@ -1,0 +1,27 @@
+package com.team04.back.domain.cloth.clothinfo.entity;
+
+import com.team04.back.domain.cloth.clothinfo.enums.Category;
+import jakarta.persistence.*;
+
+@Entity
+public class ClothInfo{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(nullable = false)
+    private String clothName;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+
+    @Column(nullable = false)
+    private Double maxFeelsLike;
+
+    @Column(nullable = false)
+    private Double minFeelsLike;
+}

--- a/src/main/java/com/team04/back/domain/cloth/clothinfo/entity/ClothInfo.java
+++ b/src/main/java/com/team04/back/domain/cloth/clothinfo/entity/ClothInfo.java
@@ -2,8 +2,14 @@ package com.team04.back.domain.cloth.clothinfo.entity;
 
 import com.team04.back.domain.cloth.clothinfo.enums.Category;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ClothInfo{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,4 +30,36 @@ public class ClothInfo{
 
     @Column(nullable = false)
     private Double minFeelsLike;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private ClothInfo(String clothName, String imageUrl, Category category, Double maxFeelsLike, Double minFeelsLike) {
+        this.clothName = clothName;
+        this.imageUrl = imageUrl;
+        this.category = category;
+        this.maxFeelsLike = maxFeelsLike;
+        this.minFeelsLike = minFeelsLike;
+    }
+
+    public static ClothInfo create(String clothName, String imageUrl, Category category, Double maxFeelsLike, Double minFeelsLike) {
+        if (clothName == null || clothName.isBlank()) {
+            throw new IllegalArgumentException("Cloth name cannot be empty.");
+        }
+        if (imageUrl == null || imageUrl.isBlank()) {
+            throw new IllegalArgumentException("Image URL cannot be empty.");
+        }
+        if (category == null) {
+            throw new IllegalArgumentException("Category cannot be null.");
+        }
+        if (maxFeelsLike == null || minFeelsLike == null) {
+            throw new IllegalArgumentException("Feels like temperatures cannot be null.");
+        }
+
+        return ClothInfo.builder()
+                .clothName(clothName)
+                .imageUrl(imageUrl)
+                .category(category)
+                .maxFeelsLike(maxFeelsLike)
+                .minFeelsLike(minFeelsLike)
+                .build();
+    }
 }

--- a/src/main/java/com/team04/back/domain/cloth/clothinfo/entity/ClothInfo.java
+++ b/src/main/java/com/team04/back/domain/cloth/clothinfo/entity/ClothInfo.java
@@ -62,4 +62,22 @@ public class ClothInfo{
                 .minFeelsLike(minFeelsLike)
                 .build();
     }
+
+    public void update(String clothName, String imageUrl, Category category, Double maxFeelsLike, Double minFeelsLike) {
+        if (clothName != null && !clothName.isBlank()) {
+            this.clothName = clothName;
+        }
+        if (imageUrl != null && !imageUrl.isBlank()) {
+            this.imageUrl = imageUrl;
+        }
+        if (category != null) {
+            this.category = category;
+        }
+        if (maxFeelsLike != null) {
+            this.maxFeelsLike = maxFeelsLike;
+        }
+        if (minFeelsLike != null) {
+            this.minFeelsLike = minFeelsLike;
+        }
+    }
 }

--- a/src/main/java/com/team04/back/domain/cloth/clothinfo/enums/Category.java
+++ b/src/main/java/com/team04/back/domain/cloth/clothinfo/enums/Category.java
@@ -1,0 +1,7 @@
+package com.team04.back.domain.cloth.clothinfo.enums;
+
+public enum Category {
+    상의,
+    하의,
+    아우터
+}

--- a/src/main/java/com/team04/back/domain/cloth/clothinfo/repository/ClothInfoRepository.java
+++ b/src/main/java/com/team04/back/domain/cloth/clothinfo/repository/ClothInfoRepository.java
@@ -1,0 +1,9 @@
+package com.team04.back.domain.cloth.clothinfo.repository;
+
+import com.team04.back.domain.cloth.clothinfo.entity.ClothInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ClothInfoRepository extends JpaRepository<ClothInfo, Integer> {
+}

--- a/src/main/java/com/team04/back/domain/cloth/clothinfo/service/ClothInfoService.java
+++ b/src/main/java/com/team04/back/domain/cloth/clothinfo/service/ClothInfoService.java
@@ -1,0 +1,7 @@
+package com.team04.back.domain.cloth.clothinfo.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ClothInfoService {
+}

--- a/src/main/java/com/team04/back/domain/cloth/clothinfo/service/ClothInfoService.java
+++ b/src/main/java/com/team04/back/domain/cloth/clothinfo/service/ClothInfoService.java
@@ -1,7 +1,27 @@
 package com.team04.back.domain.cloth.clothinfo.service;
 
+import com.team04.back.domain.cloth.clothinfo.repository.ClothInfoRepository;
+import com.team04.back.domain.weather.weather.repository.WeatherRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+
 @Service
+@RequiredArgsConstructor
 public class ClothInfoService {
+    private final ClothInfoRepository clothInfoRepository;
+    private final WeatherRepository weatherRepository;
+
+    public void getOutfitWithPeriod(String place, LocalDate start, LocalDate end) {
+        //1. 단 기간에 해당하는 날씨정보 조회
+//        weatherRepository.findByLocationAndDateBetween(place, start, end);
+                //  1.만약 업데이트 시간이 1시간이 넘어갔거나 날씨 정보가 없다면 API재요청을 통해 날씨 정보를 업데이트한다
+
+
+        //2. 기간의 각 일자별(일별 평균 체감기온 기준) 상의, 하의를 조회한다. 상/하의는 각각 최소 1개 이상이어야한다.
+        //  2.1 아우터도 검색한다. 아우터는 0개 이상이어야한다.
+        //3.일자별 기상상태에 따라 추가물품이 필요하다 판단되면 추가 물품(ExtraCloth)을 조회한다
+        //  3.1 추가물품은 기상 상태별1개 이상이어야 한다.
+    }
 }

--- a/src/main/java/com/team04/back/domain/cloth/extracloth/entity/ExtraCloth.java
+++ b/src/main/java/com/team04/back/domain/cloth/extracloth/entity/ExtraCloth.java
@@ -1,0 +1,21 @@
+package com.team04.back.domain.cloth.extracloth.entity;
+
+import com.team04.back.domain.weather.weather.enums.Weather;
+import jakarta.persistence.*;
+
+@Entity
+public class ExtraCloth{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(nullable = false)
+    private String clothName;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Weather weather;
+}

--- a/src/main/java/com/team04/back/infra/weather/WeatherApiClient.java
+++ b/src/main/java/com/team04/back/infra/weather/WeatherApiClient.java
@@ -1,0 +1,61 @@
+package com.team04.back.infra.weather;
+
+import com.team04.back.infra.weather.dto.OneCallApiResponse;
+import com.team04.back.infra.weather.dto.TimeMachineApiResponse;
+import com.team04.back.infra.weather.dto.DaySummaryApiResponse;
+import com.team04.back.infra.weather.dto.WeatherOverviewApiResponse;
+import jakarta.validation.constraints.NotNull;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+public interface WeatherApiClient {
+
+    /**
+     * Current and forecasts weather data.
+     * 현재 및 예보 날씨 데이터를 가져옵니다.
+     * @param lat 위도, 십진수 (-90; 90). (필수)
+     * @param lon 경도, 십진수 (-180; 180). (필수)
+     * @param exclude API 응답에서 제외할 날씨 데이터 부분 (예: ["current", "minutely"]). (선택 사항)
+     * @param units 측정 단위. "standard", "metric", "imperial" 사용 가능. (선택 사항)
+     * @param lang 출력 언어. (선택 사항)
+     * @return 구조화된 DTO로 날씨 데이터를 포함하는 Mono.
+     */
+    Mono<OneCallApiResponse> fetchOneCallWeatherData(@NotNull double lat, @NotNull double lon, List<String> exclude, String units, String lang);
+
+    /**
+     * Weather data for timestamp.
+     * 특정 타임스탬프에 대한 날씨 데이터를 가져옵니다.
+     * @param lat 위도, 십진수 (-90; 90). (필수)
+     * @param lon 경도, 십진수 (-180; 180). (필수)
+     * @param dt 타임스탬프 (Unix 시간, UTC 시간대). (필수)
+     * @param units 측정 단위. "standard", "metric", "imperial" 사용 가능. (선택 사항)
+     * @param lang 출력 언어. (선택 사항)
+     * @return 구조화된 DTO로 날씨 데이터를 포함하는 Mono.
+     */
+    Mono<TimeMachineApiResponse> fetchTimeMachineWeatherData(@NotNull double lat, @NotNull double lon, @NotNull long dt, String units, String lang);
+
+    /**
+     * Daily Aggregation.
+     * 특정 날짜에 대한 집계된 날씨 데이터를 가져옵니다.
+     * @param lat 위도, 십진수 (-90; 90). (필수)
+     * @param lon 경도, 십진수 (-180; 180). (필수)
+     * @param date YYYY-MM-DD 형식의 날짜. (필수)
+     * @param tz 시간대 (±XX:XX 형식). (선택 사항)
+     * @param units 측정 단위. "standard", "metric", "imperial" 사용 가능. (선택 사항)
+     * @return 구조화된 DTO로 일별 요약 날씨 데이터를 포함하는 Mono.
+     */
+    Mono<DaySummaryApiResponse> fetchDaySummaryWeatherData(@NotNull double lat, @NotNull double lon, @NotNull String date, String tz, String units);
+
+    /**
+     * Weather overview
+     * 사람이 읽을 수 있는 형태의 날씨 요약을 가져옵니다.
+     * @param lat 위도, 십진수 (-90; 90). (필수)
+     * @param lon 경도, 십진수 (-180; 180). (필수)
+     * @param date YYYY-MM-DD 형식의 날짜. (선택 사항)
+     * @param units 측정 단위. "standard", "metric", "imperial" 사용 가능. (선택 사항)
+     * @return 구조화된 DTO로 날씨 개요를 포함하는 Mono.
+     */
+    Mono<WeatherOverviewApiResponse> fetchWeatherOverview(@NotNull double lat, @NotNull double lon, String date, String units);
+
+}

--- a/src/main/java/com/team04/back/infra/weather/WeatherApiClientImpl.java
+++ b/src/main/java/com/team04/back/infra/weather/WeatherApiClientImpl.java
@@ -1,0 +1,87 @@
+package com.team04.back.infra.weather;
+
+import com.team04.back.infra.weather.dto.OneCallApiResponse;
+import com.team04.back.infra.weather.dto.TimeMachineApiResponse;
+import com.team04.back.infra.weather.dto.DaySummaryApiResponse;
+import com.team04.back.infra.weather.dto.WeatherOverviewApiResponse;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class WeatherApiClientImpl implements WeatherApiClient {
+
+    private final WebClient webClient;
+
+    @Value("${openweather.api.key}")
+    private String apiKey;
+
+    @Override
+    public Mono<OneCallApiResponse> fetchOneCallWeatherData(@NotNull double lat, @NotNull double lon, List<String> exclude, String units, String lang) {
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/data/3.0/onecall")
+                        .queryParam("lat", lat)
+                        .queryParam("lon", lon)
+                        .queryParam("exclude", String.join(",", exclude))
+                        .queryParam("units", units)
+                        .queryParam("lang", lang)
+                        .queryParam("appid", apiKey)
+                        .build())
+                .retrieve()
+                .bodyToMono(OneCallApiResponse.class);
+    }
+
+    @Override
+    public Mono<TimeMachineApiResponse> fetchTimeMachineWeatherData(@NotNull double lat, @NotNull double lon, @NotNull long dt, String units, String lang) {
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/data/3.0/onecall/timemachine")
+                        .queryParam("lat", lat)
+                        .queryParam("lon", lon)
+                        .queryParam("dt", dt)
+                        .queryParam("units", units)
+                        .queryParam("lang", lang)
+                        .queryParam("appid", apiKey)
+                        .build())
+                .retrieve()
+                .bodyToMono(TimeMachineApiResponse.class);
+    }
+
+    @Override
+    public Mono<DaySummaryApiResponse> fetchDaySummaryWeatherData(@NotNull double lat, @NotNull double lon, @NotNull String date, String tz, String units) {
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/data/3.0/onecall/day_summary")
+                        .queryParam("lat", lat)
+                        .queryParam("lon", lon)
+                        .queryParam("date", date)
+                        .queryParam("tz", tz)
+                        .queryParam("units", units)
+                        .queryParam("appid", apiKey)
+                        .build())
+                .retrieve()
+                .bodyToMono(DaySummaryApiResponse.class);
+    }
+
+    @Override
+    public Mono<WeatherOverviewApiResponse> fetchWeatherOverview(@NotNull double lat, @NotNull double lon, String date, String units) {
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/data/3.0/onecall/overview")
+                        .queryParam("lat", lat)
+                        .queryParam("lon", lon)
+                        .queryParam("date", date)
+                        .queryParam("units", units)
+                        .queryParam("appid", apiKey)
+                        .build())
+                .retrieve()
+                .bodyToMono(WeatherOverviewApiResponse.class);
+    }
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/AlertData.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/AlertData.java
@@ -1,0 +1,21 @@
+package com.team04.back.infra.weather.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AlertData {
+    private String sender_name;
+    private String event;
+    private long start;
+    private long end;
+    private String description;
+    private List<String> tags;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/CloudCover.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/CloudCover.java
@@ -1,0 +1,14 @@
+package com.team04.back.infra.weather.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CloudCover {
+    private int afternoon;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/CurrentWeather.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/CurrentWeather.java
@@ -1,0 +1,36 @@
+package com.team04.back.infra.weather.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CurrentWeather {
+    private long dt;
+    private long sunrise;
+    private long sunset;
+    private double temp;
+    @JsonProperty("feels_like")
+    private double feelsLike;
+    private int pressure;
+    private int humidity;
+    @JsonProperty("dew_point")
+    private double dewPoint;
+    private double uvi;
+    private int clouds;
+    private int visibility;
+    @JsonProperty("wind_speed")
+    private double windSpeed;
+    @JsonProperty("wind_deg")
+    private int windDeg;
+    @JsonProperty("wind_gust")
+    private double windGust;
+    private List<WeatherDescription> weather;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/DailyData.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/DailyData.java
@@ -1,0 +1,42 @@
+package com.team04.back.infra.weather.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyData {
+    private long dt;
+    private long sunrise;
+    private long sunset;
+    private long moonrise;
+    private long moonset;
+    @JsonProperty("moon_phase")
+    private double moonPhase;
+    private String summary;
+    private DailyTemp temp;
+    @JsonProperty("feels_like")
+    private DailyFeelsLike feelsLike;
+    private int pressure;
+    private int humidity;
+    @JsonProperty("dew_point")
+    private double dewPoint;
+    @JsonProperty("wind_speed")
+    private double windSpeed;
+    @JsonProperty("wind_deg")
+    private int windDeg;
+    @JsonProperty("wind_gust")
+    private double windGust;
+    private List<WeatherDescription> weather;
+    private int clouds;
+    private double pop;
+    private double rain;
+    private double uvi;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/DailyFeelsLike.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/DailyFeelsLike.java
@@ -1,0 +1,17 @@
+package com.team04.back.infra.weather.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyFeelsLike {
+    private double day;
+    private double night;
+    private double eve;
+    private double morn;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/DailyTemp.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/DailyTemp.java
@@ -1,0 +1,19 @@
+package com.team04.back.infra.weather.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyTemp {
+    private double day;
+    private double min;
+    private double max;
+    private double night;
+    private double eve;
+    private double morn;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/DaySummaryApiResponse.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/DaySummaryApiResponse.java
@@ -1,0 +1,59 @@
+package com.team04.back.infra.weather.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DaySummaryApiResponse {
+    /**
+     * 위도, 십진수 (-90; 90)
+     */
+    private double lat;
+    /**
+     * 경도, 십진수 (-180; 180)
+     */
+    private double lon;
+    /**
+     * 시간대 (±XX:XX 형식)
+     */
+    private String tz;
+    /**
+     * API 요청에 지정된 날짜 (YYYY-MM-DD 형식)
+     */
+    private String date;
+    /**
+     * 요청에 지정된 측정 단위
+     */
+    private String units;
+    /**
+     * 구름 관련 정보
+     */
+    @JsonProperty("cloud_cover")
+    private CloudCover cloudCover;
+    /**
+     * 습도 관련 정보
+     */
+    private HumiditySummary humidity;
+    /**
+     * 강수량 관련 정보
+     */
+    private PrecipitationSummary precipitation;
+    /**
+     * 온도 관련 정보
+     */
+    private TemperatureSummary temperature;
+    /**
+     * 기압 관련 정보
+     */
+    private PressureSummary pressure;
+    /**
+     * 바람 관련 정보
+     */
+    private WindSummary wind;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/HourlyData.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/HourlyData.java
@@ -1,0 +1,35 @@
+package com.team04.back.infra.weather.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class HourlyData {
+    private long dt;
+    private double temp;
+    @JsonProperty("feels_like")
+    private double feelsLike;
+    private int pressure;
+    private int humidity;
+    @JsonProperty("dew_point")
+    private double dewPoint;
+    private double uvi;
+    private int clouds;
+    private int visibility;
+    @JsonProperty("wind_speed")
+    private double windSpeed;
+    @JsonProperty("wind_deg")
+    private int windDeg;
+    @JsonProperty("wind_gust")
+    private double windGust;
+    private List<WeatherDescription> weather;
+    private double pop;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/HumiditySummary.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/HumiditySummary.java
@@ -1,0 +1,14 @@
+package com.team04.back.infra.weather.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class HumiditySummary {
+    private int afternoon;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/MinutelyData.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/MinutelyData.java
@@ -1,0 +1,15 @@
+package com.team04.back.infra.weather.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MinutelyData {
+    private long dt;
+    private double precipitation;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/OneCallApiResponse.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/OneCallApiResponse.java
@@ -1,0 +1,53 @@
+package com.team04.back.infra.weather.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OneCallApiResponse {
+    /**
+     * 위도, 십진수 (-90; 90)
+     */
+    private double lat;
+    /**
+     * 경도, 십진수 (-180; 180)
+     */
+    private double lon;
+    /**
+     * 요청된 위치의 시간대 이름
+     */
+    private String timezone;
+    /**
+     * UTC로부터의 시간 오프셋 (초)
+     */
+    @JsonProperty("timezone_offset")
+    private int timezoneOffset;
+    /**
+     * 현재 날씨 데이터
+     */
+    private CurrentWeather current;
+    /**
+     * 1시간 동안의 분 단위 예보 데이터
+     */
+    private List<MinutelyData> minutely;
+    /**
+     * 48시간 동안의 시간 단위 예보 데이터
+     */
+    private List<HourlyData> hourly;
+    /**
+     * 8일 동안의 일 단위 예보 데이터
+     */
+    private List<DailyData> daily;
+    /**
+     * 국가 날씨 경보 데이터
+     */
+    private List<AlertData> alerts;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/PrecipitationSummary.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/PrecipitationSummary.java
@@ -1,0 +1,14 @@
+package com.team04.back.infra.weather.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PrecipitationSummary {
+    private double total;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/PressureSummary.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/PressureSummary.java
@@ -1,0 +1,14 @@
+package com.team04.back.infra.weather.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PressureSummary {
+    private int afternoon;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/TemperatureSummary.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/TemperatureSummary.java
@@ -1,0 +1,19 @@
+package com.team04.back.infra.weather.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TemperatureSummary {
+    private double min;
+    private double max;
+    private double afternoon;
+    private double night;
+    private double evening;
+    private double morning;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/TimeMachineApiResponse.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/TimeMachineApiResponse.java
@@ -1,0 +1,37 @@
+package com.team04.back.infra.weather.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimeMachineApiResponse {
+    /**
+     * 위도, 십진수 (-90; 90)
+     */
+    private double lat;
+    /**
+     * 경도, 십진수 (-180; 180)
+     */
+    private double lon;
+    /**
+     * 요청된 위치의 시간대 이름
+     */
+    private String timezone;
+    /**
+     * UTC로부터의 시간 오프셋 (초)
+     */
+    @JsonProperty("timezone_offset")
+    private int timezoneOffset;
+    /**
+     * 타임머신 날씨 데이터 배열
+     */
+    private List<TimeMachineData> data;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/TimeMachineData.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/TimeMachineData.java
@@ -1,0 +1,34 @@
+package com.team04.back.infra.weather.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimeMachineData {
+    private long dt;
+    private long sunrise;
+    private long sunset;
+    private double temp;
+    @JsonProperty("feels_like")
+    private double feelsLike;
+    private int pressure;
+    private int humidity;
+    @JsonProperty("dew_point")
+    private double dewPoint;
+    private double uvi;
+    private int clouds;
+    private int visibility;
+    @JsonProperty("wind_speed")
+    private double windSpeed;
+    @JsonProperty("wind_deg")
+    private int windDeg;
+    private List<WeatherDescription> weather;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/WeatherDescription.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/WeatherDescription.java
@@ -1,0 +1,17 @@
+package com.team04.back.infra.weather.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WeatherDescription {
+    private int id;
+    private String main;
+    private String description;
+    private String icon;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/WeatherOverviewApiResponse.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/WeatherOverviewApiResponse.java
@@ -1,0 +1,39 @@
+package com.team04.back.infra.weather.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WeatherOverviewApiResponse {
+    /**
+     * 위도, 십진수 (-90; 90)
+     */
+    private double lat;
+    /**
+     * 경도, 십진수 (-180; 180)
+     */
+    private double lon;
+    /**
+     * 시간대 (±XX:XX 형식)
+     */
+    private String tz;
+    /**
+     * 요약이 생성된 날짜 (YYYY-MM-DD 형식)
+     */
+    private String date;
+    /**
+     * 요청에 지정된 측정 단위
+     */
+    private String units;
+    /**
+     * AI가 생성한 요청된 날짜의 날씨 개요
+     */
+    @JsonProperty("weather_overview")
+    private String weatherOverview;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/WindMax.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/WindMax.java
@@ -1,0 +1,15 @@
+package com.team04.back.infra.weather.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WindMax {
+    private double speed;
+    private int direction;
+}

--- a/src/main/java/com/team04/back/infra/weather/dto/WindSummary.java
+++ b/src/main/java/com/team04/back/infra/weather/dto/WindSummary.java
@@ -1,0 +1,14 @@
+package com.team04.back.infra.weather.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WindSummary {
+    private WindMax max;
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -4,3 +4,7 @@ spring:
     username: sa                         # 기본 사용자 이름
     password:                            # 비밀번호 없음
     driver-class-name: org.h2.Driver     # H2 DB용 드라이버
+
+openweather:
+  api:
+    key: API-KEY-HERE

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,3 +26,7 @@ server:
       charset: UTF-8   # 문자 인코딩 UTF-8로 설정 (한글 깨짐 방지)
       enabled: true    # 인코딩 설정 켜기
       force: true      # 모든 요청/응답에 UTF-8 강제로 적용
+
+openweather:
+  api:
+    key: API-KEY-HERE

--- a/src/test/java/com/team04/back/infra/weather/WeatherApiClientImplE2ETest.java
+++ b/src/test/java/com/team04/back/infra/weather/WeatherApiClientImplE2ETest.java
@@ -1,0 +1,100 @@
+package com.team04.back.infra.weather;
+
+import com.team04.back.infra.weather.dto.DaySummaryApiResponse;
+import com.team04.back.infra.weather.dto.OneCallApiResponse;
+import com.team04.back.infra.weather.dto.TimeMachineApiResponse;
+import com.team04.back.infra.weather.dto.WeatherOverviewApiResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class WeatherApiClientImplE2ETest {
+
+    @Autowired
+    private WeatherApiClient weatherApiClient;
+
+    private final double TEST_LAT = 37.5665;
+    private final double TEST_LON = 126.9780;
+    private final String TEST_UNITS = "metric";
+    private final String TEST_LANG = "kr";
+
+    @DisplayName("One Call API - Current and forecasts weather data 호출 테스트")
+    @Test
+    void testFetchOneCallWeatherData() {
+        List<String> exclude = Arrays.asList("minutely", "hourly", "daily", "alerts");
+        Mono<OneCallApiResponse> responseMono = weatherApiClient.fetchOneCallWeatherData(
+                TEST_LAT, TEST_LON, exclude, TEST_UNITS, TEST_LANG
+        );
+
+        OneCallApiResponse response = responseMono.block();
+
+        assertNotNull(response);
+        assertNotNull(response.getCurrent());
+        System.out.println("One Call API Response: " + response.getCurrent().getTemp() + " " + response.getCurrent().getWeather().get(0).getDescription());
+    }
+
+    @DisplayName("One Call API - Weather data for timestamp API 호출 테스트")
+    @Test
+    void testFetchTimeMachineWeatherData() {
+        long dt = LocalDate.of(2023, 1, 1).atStartOfDay().toEpochSecond(ZoneOffset.UTC);
+
+        Mono<TimeMachineApiResponse> responseMono = weatherApiClient.fetchTimeMachineWeatherData(
+                TEST_LAT, TEST_LON, dt, TEST_UNITS, TEST_LANG
+        );
+
+        TimeMachineApiResponse response = responseMono.block();
+
+        assertNotNull(response);
+        assertNotNull(response.getData());
+        assertTrue(response.getData().size() > 0);
+        System.out.println("Time Machine API Response: " + response.getData().get(0).getTemp() + " " + response.getData().get(0).getWeather().get(0).getDescription());
+    }
+
+    @DisplayName("One Call API - Daily Aggregation API 호출 테스트")
+    @Test
+    void testFetchDaySummaryWeatherData() {
+        String date = "2023-03-30";
+        String tz = "+09:00";
+
+        Mono<DaySummaryApiResponse> responseMono = weatherApiClient.fetchDaySummaryWeatherData(
+                TEST_LAT, TEST_LON, date, tz, TEST_UNITS
+        );
+
+        DaySummaryApiResponse response = responseMono.block();
+
+        assertNotNull(response);
+        assertNotNull(response.getTemperature());
+        System.out.println("Day Summary API Response: Min Temp: " + response.getTemperature().getMin() + ", Max Temp: " + response.getTemperature().getMax());
+    }
+
+    @DisplayName("One Call API - Weather Overview API 호출 테스트")
+    @Test
+    void testFetchWeatherOverview() {
+        String date = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+        Mono<WeatherOverviewApiResponse> responseMono = weatherApiClient.fetchWeatherOverview(
+                TEST_LAT, TEST_LON, date, TEST_UNITS
+        );
+
+        WeatherOverviewApiResponse response = responseMono.block();
+
+        assertNotNull(response);
+        assertNotNull(response.getWeatherOverview());
+        assertTrue(response.getWeatherOverview().length() > 0);
+        System.out.println("Weather Overview API Response: " + response.getWeatherOverview());
+    }
+}


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

-  OpenWeather의 One Call API 3.0을 활용하여 날씨 데이터를  조회하고 처리하기 위한 WebClient를 구현합니다.

## 🔨 작업 내용

 - OpenWeatherMap One Call API 3.0 연동을 위한 WebClient 설정 및 구현
 - API 응답 데이터를 처리하기 위한 DTO(Data Transfer Object) 정의
 - 날씨 정보 요청 및 응답 처리를 위한 `WeatherApiClient` 인터페이스 및 `WeatherApiClientImpl` 구현

## 🔗 관련 이슈

Closes #22

## 📝 참고 사항

- 

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 작성
- [x] 문서/주석 추가 및 최신화


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 날씨 API와 연동되는 날씨 데이터 조회 기능이 추가되었습니다.
  * 의류 정보 및 추천을 위한 엔티티, 서비스, 컨트롤러가 도입되었습니다.
  * 의류 카테고리 및 추가 의류(ExtraCloth) 엔티티가 추가되었습니다.

* **설정**
  * OpenWeather API 키와 관련 설정이 환경설정 파일에 추가되었습니다.
  * WebFlux 및 WebClient 기반의 비동기 HTTP 통신이 지원됩니다.

* **테스트**
  * 날씨 API 클라이언트의 주요 기능을 검증하는 통합 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->