### PR TITLE
chore: SpringDocConfig 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/team04/back/config/SpringDocConfig.java
+++ b/src/main/java/com/team04/back/config/SpringDocConfig.java
@@ -1,0 +1,15 @@
+package com.team04.back.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @io.swagger.v3.oas.annotations.info.Info(
+                title = "API documentation",
+                version = "v1",
+                description = "API documentation for Team04 project"
+        )
+)
+public class SpringDocConfig {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,9 @@ spring:
   config:
     import: optional:file:application-secret.yml # 비밀 설정 파일을 선택적으로 가져오기 (존재할 경우만)
 
+springdoc:
+  default-produces-media-type: application/json;charset=UTF-8 # 기본 응답 타입 설정
+
 logging:
   level:
     org.hibernate.orm.jdbc.bind: TRACE     # 바인딩된 SQL 파라미터 출력


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

-

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

- 컨트롤러에서 Swagger 문서 세부 정보 추가는 다음과 같이 하면 됨
  - `@Tag`
  - `@Operation`
```java
// 예시

@Tag(name = "Auth", description = "인증 관련 API")
@RestController
@RequestMapping("/auth")
public class AuthController {

    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
    @ApiResponses({
        @ApiResponse(responseCode = "200", description = "로그인 성공"),
        @ApiResponse(responseCode = "401", description = "잘못된 자격 증명")
    })
    @PostMapping("/login")
    public ResponseEntity<Void> login(@RequestBody LoginRequest request) {
        ...
    }
}
```

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #36

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

-

## ✅ 체크리스트

- [ ] 기능 동작 확인
- [ ] 테스트 코드 작성
- [ ] 문서/주석 추가 및 최신화


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * OpenAPI 기반의 자동 API 문서화 기능이 추가되었습니다. 이제 프로젝트에서 API 문서를 자동으로 생성하고 UI로 확인할 수 있습니다.

* **문서화**
  * API 문서의 기본 정보(제목, 버전, 설명)가 설정되었습니다.
  * API 응답의 기본 미디어 타입이 UTF-8 인코딩된 JSON으로 지정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->