### PR TITLE
perf: wether enum 범주 지정

### DIFF
--- a/src/main/java/com/team04/back/domain/cloth/cloth/controller/ClothController.java
+++ b/src/main/java/com/team04/back/domain/cloth/cloth/controller/ClothController.java
@@ -1,11 +1,14 @@
 package com.team04.back.domain.cloth.cloth.controller;
 
 import com.team04.back.domain.cloth.cloth.dto.CategoryClothDto;
+import com.team04.back.domain.cloth.cloth.dto.ExtraClothDto;
 import com.team04.back.domain.cloth.cloth.dto.OutfitResponse;
 import com.team04.back.domain.cloth.cloth.dto.WeatherClothResponseDto;
 import com.team04.back.domain.cloth.cloth.entity.Clothing;
+import com.team04.back.domain.cloth.cloth.entity.ExtraCloth;
 import com.team04.back.domain.cloth.cloth.enums.Category;
 import com.team04.back.domain.cloth.cloth.service.ClothService;
+import com.team04.back.domain.weather.weather.dto.WeatherInfoDto;
 import com.team04.back.domain.weather.weather.entity.WeatherInfo;
 import com.team04.back.domain.weather.weather.service.WeatherService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,6 +25,8 @@ import org.springframework.web.bind.annotation.RestController;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/cloth")
@@ -44,8 +49,15 @@ public class ClothController {
         // 날씨 정보에 따라 옷 정보 가져오기
         List<CategoryClothDto> cloths = clothService.findClothByWeather(weatherInfo.getFeelsLikeTemperature());
 
+        // 날씨 정보에 따라 추가 옷 정보 가져오기
+        Set<ExtraCloth> extraCloth = clothService.getExtraClothes(weatherInfo);
+
         // 날씨 정보와 옷 정보를 포함한 응답 DTO 리턴
-        return new WeatherClothResponseDto(weatherInfo, cloths);
+        WeatherInfoDto weatherInfoDto = new WeatherInfoDto(weatherInfo);
+        Set<ExtraClothDto> extraClothDto  =extraCloth.stream()
+                .map(ExtraClothDto::new)
+                .collect(Collectors.toSet());
+        return new WeatherClothResponseDto(weatherInfoDto, cloths, extraClothDto);
     }
 
     record TripSchedule(

--- a/src/main/java/com/team04/back/domain/cloth/cloth/dto/CategoryClothDto.java
+++ b/src/main/java/com/team04/back/domain/cloth/cloth/dto/CategoryClothDto.java
@@ -19,7 +19,4 @@ public class CategoryClothDto {
         this.category = category;
     }
 
-    public static CategoryClothDto from(int id, String clothName, String imageUrl, Category category) {
-        return new CategoryClothDto(clothName, imageUrl, category);
-    }
 }

--- a/src/main/java/com/team04/back/domain/cloth/cloth/dto/WeatherClothResponseDto.java
+++ b/src/main/java/com/team04/back/domain/cloth/cloth/dto/WeatherClothResponseDto.java
@@ -1,19 +1,22 @@
 package com.team04.back.domain.cloth.cloth.dto;
 
-import com.team04.back.domain.weather.weather.entity.WeatherInfo;
+import com.team04.back.domain.weather.weather.dto.WeatherInfoDto;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.util.List;
+import java.util.Set;
 
 @Getter
 @Setter
 public class WeatherClothResponseDto {
-    private WeatherInfo weatherInfo;
+    private WeatherInfoDto weatherInfo;
     private List<CategoryClothDto>  clothList;
+    private Set<ExtraClothDto> extraCloth;
 
-    public WeatherClothResponseDto(WeatherInfo weatherInfo, List<CategoryClothDto> clothList) {
+    public WeatherClothResponseDto(WeatherInfoDto weatherInfo, List<CategoryClothDto> clothList, Set<ExtraClothDto> extraCloth) {
         this.weatherInfo = weatherInfo;
         this.clothList = clothList;
+        this.extraCloth = extraCloth;
     }
 }

--- a/src/main/java/com/team04/back/domain/cloth/cloth/service/ClothService.java
+++ b/src/main/java/com/team04/back/domain/cloth/cloth/service/ClothService.java
@@ -8,6 +8,7 @@ import com.team04.back.domain.cloth.cloth.enums.Category;
 import com.team04.back.domain.cloth.cloth.repository.ClothRepository;
 import com.team04.back.domain.cloth.cloth.repository.ExtraClothRepository;
 import com.team04.back.domain.weather.weather.entity.WeatherInfo;
+import com.team04.back.domain.weather.weather.enums.Weather;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,9 +52,35 @@ public class ClothService {
         return recommendedClothesMap;
     }
 
-    private Set<ExtraCloth> getExtraClothes(WeatherInfo weather) {
-        Set<ExtraCloth> extraCloths = extraClothRepository.findDistinctByWeather(weather.getWeather());
-        return extraCloths;
+    public Set<ExtraCloth> getExtraClothes(WeatherInfo weather) {
+        Weather weatherGroup = getWeatherGroup(weather);
+        return extraClothRepository.findDistinctByWeather(weatherGroup);
+
+    }
+
+    private Weather getWeatherGroup(WeatherInfo weather) {
+        int code = weather.getWeather().getCode();
+
+        // 폭염- 체감기온 30 이상
+        if (weather.getFeelsLikeTemperature() != null && 30 <= weather.getFeelsLikeTemperature()) {
+            return Weather.HEAT_WAVE;
+        }
+
+        // 비 또는 뇌우
+        if (200 <= code && code < 400 || 500 <= code && code < 600)
+            return Weather.MODERATE_RAIN;
+        //눈
+        if ( 600 <= code && code < 700)
+            return Weather.SNOW;
+
+        // 안개 또는 먼지
+        if (700 <= code && code < 800)
+            return Weather.MIST;
+
+        // 그외에는 맑은 하늘로 간주
+        return Weather.CLEAR_SKY;
+
+
     }
 
 }

--- a/src/main/java/com/team04/back/domain/weather/weather/dto/WeatherInfoDto.java
+++ b/src/main/java/com/team04/back/domain/weather/weather/dto/WeatherInfoDto.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
 
+
 public record WeatherInfoDto(
         @NotNull int id,
         @NotNull String weather,

--- a/src/main/java/com/team04/back/domain/weather/weather/enums/Weather.java
+++ b/src/main/java/com/team04/back/domain/weather/weather/enums/Weather.java
@@ -73,10 +73,15 @@ public enum Weather {
     CLEAR_SKY(800, "맑은 하늘"),
 
     // Group 80x: Clouds
+
     FEW_CLOUDS(801, "약간의 구름"),
     SCATTERED_CLOUDS(802, "흩어진 구름"),
     BROKEN_CLOUDS(803, "부서진 구름"),
-    OVERCAST_CLOUDS(804, "흐린 하늘");
+    OVERCAST_CLOUDS(804, "흐린 하늘"),
+
+
+    // 폭염
+    HEAT_WAVE(900, "폭염");
 
     private final int code;
     private final String description;

--- a/src/test/java/com/team04/back/domain/cloth/cloth/service/ClothServiceTest.java
+++ b/src/test/java/com/team04/back/domain/cloth/cloth/service/ClothServiceTest.java
@@ -26,7 +26,6 @@ import static com.team04.back.common.fixture.FixtureFactory.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 class ClothServiceTest {
@@ -54,30 +53,28 @@ class ClothServiceTest {
         ClothInfo formalShirt = createClothInfo(Category.FORMAL_OFFICE, 10.0, 20.0);
         ClothInfo runningShoes = createClothInfo(Category.OUTDOOR, 18.0, 28.0);
 
-
         when(clothRepository.findByTemperature(hotWeather.getFeelsLikeTemperature()))
-            .thenReturn(List.of(summerTee, shorts, runningShoes));
+                .thenReturn(List.of(summerTee, shorts, runningShoes));
         when(clothRepository.findByTemperature(mildWeather.getFeelsLikeTemperature()))
-            .thenReturn(List.of(springJacket, jeans, formalShirt));
+                .thenReturn(List.of(springJacket, jeans, formalShirt));
         when(clothRepository.findByTemperature(coldWeather.getFeelsLikeTemperature()))
-            .thenReturn(List.of(winterCoat, scarf));
+                .thenReturn(List.of(winterCoat, scarf));
 
         ExtraCloth mask = createExtraCloth("마스크", "mask.jpg", Weather.FOG);
         ExtraCloth umbrella = createExtraCloth("우산", "umbrella.jpg", Weather.HEAVY_RAIN);
 
-        when(extraClothRepository.findDistinctByWeather(hotWeather.getWeather()))
-            .thenReturn(Set.of(mask));
-        when(extraClothRepository.findDistinctByWeather(mildWeather.getWeather()))
-            .thenReturn(Set.of());
-        when(extraClothRepository.findDistinctByWeather(coldWeather.getWeather()))
-            .thenReturn(Set.of(umbrella));
+        when(extraClothRepository.findDistinctByWeather(Weather.CLEAR_SKY))
+                .thenReturn(Set.of(mask));
+        when(extraClothRepository.findDistinctByWeather(Weather.MODERATE_RAIN))
+                .thenReturn(Set.of(umbrella));
 
         Map<Category, List<Clothing>> result = clothService.getOutfitWithPeriod(weatherPlan);
 
         assertThat(result).isNotNull();
 
         assertThat(result).containsKey(Category.CASUAL_DAILY);
-        assertThat(result.get(Category.CASUAL_DAILY)).containsExactlyInAnyOrder(summerTee, shorts, springJacket, jeans, winterCoat);
+        assertThat(result.get(Category.CASUAL_DAILY)).containsExactlyInAnyOrder(
+                summerTee, shorts, springJacket, jeans, winterCoat);
         assertThat(result.get(Category.CASUAL_DAILY)).hasSize(5);
 
         assertThat(result).containsKey(Category.FORMAL_OFFICE);
@@ -88,6 +85,7 @@ class ClothServiceTest {
         assertThat(result.get(Category.OUTDOOR)).containsExactlyInAnyOrder(runningShoes, scarf);
         assertThat(result.get(Category.OUTDOOR)).hasSize(2);
 
+        // EXTRA 카테고리 검증
         assertThat(result).containsKey(Category.EXTRA);
         assertThat(result.get(Category.EXTRA)).containsExactlyInAnyOrder(mask, umbrella);
         assertThat(result.get(Category.EXTRA)).hasSize(2);


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요
1. weather enum에 폭염 추가(체감기온 30도 이상)
2. weather enum에 대한 범주 지정
3. clothdetail api 개선
<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

-

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

-

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #{이슈 번호}

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

-

## ✅ 체크리스트

- [ ] 기능 동작 확인
- [ ] 테스트 코드 작성
- [ ] 문서/주석 추가 및 최신화


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 날씨에 따른 추가 의류 추천 정보가 의류 상세 조회 응답에 포함됩니다.
  * 폭염(HEAT_WAVE) 날씨 유형이 새롭게 추가되어, 해당 조건에서 맞춤 의류 및 추가 의류가 제공됩니다.

* **버그 수정**
  * 기존 의류 목록 응답에 날씨 정보가 DTO 형태로 일관성 있게 반환됩니다.

* **테스트**
  * 폭염 조건에서 추가 의류 추천이 정상적으로 동작하는 테스트가 추가되었습니다.
  * 테스트 코드 내 모킹 및 검증 방식이 일부 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->